### PR TITLE
fix(automerge): update ecosystem identifier from "github-actions" to "github_actions"

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           ecosystem="${{ steps.metadata.outputs.package-ecosystem }}"
           update_type="${{ steps.metadata.outputs.update-type }}"
-          if [[ "$ecosystem" == "github-actions" ]] || \
+          if [[ "$ecosystem" == "github_actions" ]] || \
              [[ "$update_type" == "version-update:semver-patch" ]] || \
              [[ "$update_type" == "version-update:semver-minor" ]]; then
             echo "action=allow" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Update the ecosystem identifier to ensure compatibility with the current naming conventions. This change addresses potential issues with recognizing the ecosystem in automation workflows.